### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/CogNitozCOM/86e13782-6e00-4271-add5-df8a0f70354c/6b50bde2-48a0-4e3a-b983-654dfc1ace96/_apis/work/boardbadge/9bfe025f-b39f-41e7-bab1-92773ac4018f)](https://dev.azure.com/CogNitozCOM/86e13782-6e00-4271-add5-df8a0f70354c/_boards/board/t/6b50bde2-48a0-4e3a-b983-654dfc1ace96/Microsoft.RequirementCategory)
 ### Simple Website with NodeJS, Express & EJS view engine
 ### For Azure Kubernetes Services and Azure Container Instances (AKS / ACI )
 ### How to use this?


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#552](https://dev.azure.com/CogNitozCOM/86e13782-6e00-4271-add5-df8a0f70354c/_workitems/edit/552). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.